### PR TITLE
Add delete method

### DIFF
--- a/lib/active_support/cache/namespaced_store.rb
+++ b/lib/active_support/cache/namespaced_store.rb
@@ -33,6 +33,10 @@ module ActiveSupport::Cache
       store.fetch(namespaced(key), *args, &block)
     end
 
+    def delete(key, *args)
+      store.delete(namespaced(key), *args)
+    end
+    
     def clear
       store.delete_matched(namespace)
     end

--- a/lib/namespaced_cache/version.rb
+++ b/lib/namespaced_cache/version.rb
@@ -1,3 +1,3 @@
 module NamespacedCache
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/active_support/cache/prefixed_store_spec.rb
+++ b/spec/active_support/cache/prefixed_store_spec.rb
@@ -59,6 +59,18 @@ describe ActiveSupport::Cache::NamespacedStore do
     end
   end
 
+  describe '#delete' do
+    before do
+      store.write('prefix:key', 'value')
+    end
+
+    it 'removes the item from the cache' do
+      expect {
+        cache.delete('key')
+      }.to change { store.read('prefix:key') }.from('value').to(nil)
+    end
+  end
+
   describe '#clear' do
     before do
       store.write('prefix:key1', 'value1')


### PR DESCRIPTION
I need the delete method

```
$ bundle exec rake spec
/Users/sanjay/.rbenv/versions/2.1.2/bin/ruby -I/Users/sanjay/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib:/Users/sanjay/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-support-3.1.2/lib /Users/sanjay/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*/\*_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
........

Finished in 0.00508 seconds (files took 0.14784 seconds to load)
8 examples, 0 failures

Randomized with seed 24505
```

Why do we need this gem? Looks like it already supports name spacing? https://github.com/rails/rails/blob/eb3902e2d2921ef2b3b5d84b593ed407fd6dadbc/activesupport/lib/active_support/cache.rb#L534
